### PR TITLE
dpath revamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 script:
     - black --check --verbose --line-length=79 .
     # else mkpy warnings clog output
-    - pytest --disable-warnings --cov=mkpy 
+    - python -m pytest --disable-warnings --cov=mkpy 
 after_success:
     - pip install codecov && codecov
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ install:
     - lscpu
     - python -c 'import numpy; numpy.show_config()'
     - pip install black
-    - pip install nose  # for legacy dpath
+    - pip install nose  # for legacy dpath tests
     # install mkpy locally to build Cython and to import into notebooks
     - pip install -e .
 script:
     - black --check --verbose --line-length=79 .
-    # else mkpy warnings clog output
-    - python -m pytest --disable-warnings --cov=mkpy 
+    # python -m so pytest adds packager dir to sys.path for dpath_tests
+    - python -m pytest --disable-warnings --cov=mkpy
 after_success:
     - pip install codecov && codecov
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ install:
     - lscpu
     - python -c 'import numpy; numpy.show_config()'
     - pip install black
-    - pip install nose  # for legacy dpath)
+    - pip install nose  # for legacy dpath
     # install mkpy locally to build Cython and to import into notebooks
     - pip install -e .
 script:
     - black --check --verbose --line-length=79 .
     # else mkpy warnings clog output
-    - pytest --ignore mkpy/dpath/dpath_tests --disable-warnings --cov=mkpy 
+    - pytest --disable-warnings --cov=mkpy 
 after_success:
     - pip install codecov && codecov
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
     - lscpu
     - python -c 'import numpy; numpy.show_config()'
     - pip install black
+    - pip install nose
     # install mkpy locally to build Cython and to import into notebooks
     - pip install -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     - lscpu
     - python -c 'import numpy; numpy.show_config()'
     - pip install black
-    - pip install nose
+    - pip install nose  # for legacy dpath)
     # install mkpy locally to build Cython and to import into notebooks
     - pip install -e .
 script:

--- a/conda/how_to_make_conda_pkg.md
+++ b/conda/how_to_make_conda_pkg.md
@@ -1,0 +1,11 @@
+In active conda environemnt `active_env` or whatever, from parent directory to this one, and replace X.Y.Z with actual version 
+
+    conda-build purge
+    conda-build -c defaults -c kutaslab conda
+    mkdir -p conda_build/linux-64
+    cd conda_build
+    cp  -r ~/.conda/envs/active_env/conda-bld/linux-64 .
+    conda convert --platform all linux-64/mkpy-.X.Y.Z.actual_file_name.tar.bz2
+    anaconda login
+    anaconda upload -i -u kutaslab ./**/mkpy*X.Y.Z*.tar.bz2
+    anaconda logout

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -8,7 +8,7 @@ package:
 #   path: ../
 source:
   git_url: https://github.com/kutaslab/mkpy.git
-  # git_rev: 0.1.3
+  git_rev: v0.1.3
   git_depth: 1 # (Defaults to -1/not shallow)
 
 build:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -4,12 +4,10 @@ package:
   name: mkpy
   version: "0.1.3"
 
-# source:
-#   path: ../
 source:
   git_url: https://github.com/kutaslab/mkpy.git
   git_rev: v0.1.3
-  git_depth: 1 # (Defaults to -1/not shallow)
+  git_depth: 1  # (Defaults to -1/not shallow)
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
@@ -20,6 +18,10 @@ requirements:
     - numpy
     - setuptools
     - Cython
+
+  host:
+    - python
+    - numpy ==1.16.4=py36_0  # for fitgrid 0.4.4
 
   run:
     - python

--- a/mkpy/dpath/dpath_tests/test_path_get.py
+++ b/mkpy/dpath/dpath_tests/test_path_get.py
@@ -1,7 +1,4 @@
-import nose
-from nose.tools import raises
-import dpath.path
-import dpath.exceptions
+import mkpy.dpath as dpath
 
 
 def test_path_get_list_of_dicts():

--- a/mkpy/dpath/dpath_tests/test_path_paths.py
+++ b/mkpy/dpath/dpath_tests/test_path_paths.py
@@ -1,5 +1,6 @@
 import nose
 from nose.tools import raises
+
 # import dpath.path
 # import dpath.exceptions
 # import dpath.options
@@ -14,6 +15,7 @@ def test_path_paths_empty_key_disallowed():
     tdict = {"Empty": {"": {"Key": ""}}}
     for x in mkpy.dpath.path.paths(tdict):
         pass
+
 
 def test_path_paths_empty_key_allowed():
     tdict = {"Empty": {"": {"Key": ""}}}

--- a/mkpy/dpath/dpath_tests/test_path_paths.py
+++ b/mkpy/dpath/dpath_tests/test_path_paths.py
@@ -1,31 +1,34 @@
 import nose
 from nose.tools import raises
-import dpath.path
-import dpath.exceptions
-import dpath.options
+# import dpath.path
+# import dpath.exceptions
+# import dpath.options
+
+import mkpy.dpath.exceptions
+import mkpy.dpath.path
+import mkpy.dpath.options
 
 
-@raises(dpath.exceptions.InvalidKeyName)
+@raises(mkpy.dpath.exceptions.InvalidKeyName)
 def test_path_paths_empty_key_disallowed():
     tdict = {"Empty": {"": {"Key": ""}}}
-    for x in dpath.path.paths(tdict):
+    for x in mkpy.dpath.path.paths(tdict):
         pass
-
 
 def test_path_paths_empty_key_allowed():
     tdict = {"Empty": {"": {"Key": ""}}}
     parts = []
-    dpath.options.ALLOW_EMPTY_STRING_KEYS = True
-    for x in dpath.path.paths(tdict, dirs=False, leaves=True):
+    mkpy.dpath.options.ALLOW_EMPTY_STRING_KEYS = True
+    for x in mkpy.dpath.path.paths(tdict, dirs=False, leaves=True):
         path = x
     for x in path[:-1]:
         parts.append(x[0])
-    dpath.options.ALLOW_EMPTY_STRING_KEYS = False
+    mkpy.dpath.options.ALLOW_EMPTY_STRING_KEYS = False
     assert "/".join(parts) == "Empty//Key"
 
 
 def test_path_paths_int_keys():
-    dpath.path.validate(
+    mkpy.dpath.path.validate(
         [
             ["I", dict],
             ["am", dict],

--- a/mkpy/dpath/dpath_tests/test_types.py
+++ b/mkpy/dpath/dpath_tests/test_types.py
@@ -1,6 +1,6 @@
 import nose
-import dpath.util
 from nose.tools import assert_raises
+import mkpy.dpath as dpath
 
 try:
     # python3, especially 3.8

--- a/mkpy/dpath/dpath_tests/test_unicode.py
+++ b/mkpy/dpath/dpath_tests/test_unicode.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
-
-import nose
-import dpath.path
-import dpath.util
-
+import mkpy.dpath as dpath
 
 def test_unicode_merge():
     a = {"中": ["zhong"]}

--- a/mkpy/dpath/dpath_tests/test_unicode.py
+++ b/mkpy/dpath/dpath_tests/test_unicode.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import mkpy.dpath as dpath
 
+
 def test_unicode_merge():
     a = {"中": ["zhong"]}
     b = {"文": ["wen"]}

--- a/mkpy/dpath/dpath_tests/test_util_delete.py
+++ b/mkpy/dpath/dpath_tests/test_util_delete.py
@@ -2,6 +2,7 @@ import nose
 from nose.tools import raises
 import mkpy.dpath as dpath
 
+
 def test_delete_separator():
     dict = {"a": {"b": 0}}
     dpath.util.delete(dict, ";a;b", separator=";")

--- a/mkpy/dpath/dpath_tests/test_util_delete.py
+++ b/mkpy/dpath/dpath_tests/test_util_delete.py
@@ -1,8 +1,6 @@
 import nose
 from nose.tools import raises
-import dpath.util
-import dpath.exceptions
-
+import mkpy.dpath as dpath
 
 def test_delete_separator():
     dict = {"a": {"b": 0}}

--- a/mkpy/dpath/dpath_tests/test_util_get_values.py
+++ b/mkpy/dpath/dpath_tests/test_util_get_values.py
@@ -1,6 +1,7 @@
 import nose
 from nose.tools import assert_raises
-import dpath.util
+import mkpy.dpath as dpath
+
 
 # import mock
 from unittest import mock
@@ -44,9 +45,9 @@ def test_values():
     assert 1 in ret
     assert 2 in ret
 
-
-@mock.patch("dpath.util.search")
+@mock.patch("mkpy.dpath.util.search")
 def test_values_passes_through(searchfunc):
+
     searchfunc.return_value = []
 
     def y():

--- a/mkpy/dpath/dpath_tests/test_util_get_values.py
+++ b/mkpy/dpath/dpath_tests/test_util_get_values.py
@@ -45,6 +45,7 @@ def test_values():
     assert 1 in ret
     assert 2 in ret
 
+
 @mock.patch("mkpy.dpath.util.search")
 def test_values_passes_through(searchfunc):
 

--- a/mkpy/dpath/dpath_tests/test_util_merge.py
+++ b/mkpy/dpath/dpath_tests/test_util_merge.py
@@ -1,17 +1,17 @@
 import nose
 from nose.tools import raises
 
-import dpath.util
+import mkpy.dpath.util
 
 
 def test_merge_typesafe_and_separator():
     src = {"dict": {"integer": 0}}
     dst = {"dict": {"integer": "3"}}
     try:
-        dpath.util.merge(
+        mkpy.dpath.util.merge(
             dst,
             src,
-            flags=(dpath.util.MERGE_ADDITIVE | dpath.util.MERGE_TYPESAFE),
+            flags=(mkpy.dpath.util.MERGE_ADDITIVE | mkpy.dpath.util.MERGE_TYPESAFE),
             separator=";",
         )
     except TypeError as e:
@@ -25,35 +25,35 @@ def test_merge_typesafe_and_separator():
 def test_merge_simple_int():
     src = {"integer": 0}
     dst = {"integer": 3}
-    dpath.util.merge(dst, src)
+    mkpy.dpath.util.merge(dst, src)
     nose.tools.eq_(dst["integer"], src["integer"])
 
 
 def test_merge_simple_string():
     src = {"string": "lol I am a string"}
     dst = {"string": "lol I am a string"}
-    dpath.util.merge(dst, src)
+    mkpy.dpath.util.merge(dst, src)
     nose.tools.eq_(dst["string"], src["string"])
 
 
 def test_merge_simple_list_additive():
     src = {"list": [7, 8, 9, 10]}
     dst = {"list": [0, 1, 2, 3]}
-    dpath.util.merge(dst, src, flags=dpath.util.MERGE_ADDITIVE)
+    mkpy.dpath.util.merge(dst, src, flags=mkpy.dpath.util.MERGE_ADDITIVE)
     nose.tools.eq_(dst["list"], [0, 1, 2, 3, 7, 8, 9, 10])
 
 
 def test_merge_simple_list_replace():
     src = {"list": [7, 8, 9, 10]}
     dst = {"list": [0, 1, 2, 3]}
-    dpath.util.merge(dst, src, flags=dpath.util.MERGE_REPLACE)
+    mkpy.dpath.util.merge(dst, src, flags=mkpy.dpath.util.MERGE_REPLACE)
     nose.tools.eq_(dst["list"], [7, 8, 9, 10])
 
 
 def test_merge_simple_dict():
     src = {"dict": {"key": "WEHAW"}}
     dst = {"dict": {"key": ""}}
-    dpath.util.merge(dst, src)
+    mkpy.dpath.util.merge(dst, src)
     nose.tools.eq_(dst["dict"]["key"], src["dict"]["key"])
 
 
@@ -69,7 +69,7 @@ def test_merge_filter():
         "otherdict": {"key3": "I shouldn't be here"},
     }
     dst = {}
-    dpath.util.merge(dst, src, afilter=afilter)
+    mkpy.dpath.util.merge(dst, src, afilter=afilter)
     assert "key2" in dst
     assert "key" not in dst
     assert "otherdict" not in dst
@@ -79,4 +79,4 @@ def test_merge_filter():
 def test_merge_typesafe():
     src = {"dict": {}}
     dst = {"dict": []}
-    dpath.util.merge(dst, src, flags=dpath.util.MERGE_TYPESAFE)
+    mkpy.dpath.util.merge(dst, src, flags=mkpy.dpath.util.MERGE_TYPESAFE)

--- a/mkpy/dpath/dpath_tests/test_util_merge.py
+++ b/mkpy/dpath/dpath_tests/test_util_merge.py
@@ -11,7 +11,9 @@ def test_merge_typesafe_and_separator():
         mkpy.dpath.util.merge(
             dst,
             src,
-            flags=(mkpy.dpath.util.MERGE_ADDITIVE | mkpy.dpath.util.MERGE_TYPESAFE),
+            flags=(
+                mkpy.dpath.util.MERGE_ADDITIVE | mkpy.dpath.util.MERGE_TYPESAFE
+            ),
             separator=";",
         )
     except TypeError as e:

--- a/mkpy/dpath/dpath_tests/test_util_new.py
+++ b/mkpy/dpath/dpath_tests/test_util_new.py
@@ -1,5 +1,4 @@
-import nose
-import dpath.util
+import mkpy.dpath as dpath
 
 
 def test_set_new_separator():
@@ -22,10 +21,10 @@ def test_set_new_list():
     dict = {"a": []}
     dpath.util.new(dict, "/a/1", 1)
     assert dict["a"][1] == 1
-    assert dict["a"][0] == None
+    assert dict["a"][0] is None
     dpath.util.new(dict, ["a", "1"], 1)
     assert dict["a"][1] == 1
-    assert dict["a"][0] == None
+    assert dict["a"][0] is None
 
 
 def test_set_new_list_path_with_separator():

--- a/mkpy/dpath/dpath_tests/test_util_paths.py
+++ b/mkpy/dpath/dpath_tests/test_util_paths.py
@@ -1,6 +1,4 @@
-import nose
-from nose.tools import raises
-import dpath.util
+import mkpy.dpath as dpath
 
 
 def test_util_safe_path_list():

--- a/mkpy/dpath/dpath_tests/test_util_search.py
+++ b/mkpy/dpath/dpath_tests/test_util_search.py
@@ -1,5 +1,4 @@
-import nose
-import dpath.util
+import mkpy.dpath as dpath
 
 
 def test_search_paths_with_separator():

--- a/mkpy/dpath/dpath_tests/test_util_set.py
+++ b/mkpy/dpath/dpath_tests/test_util_set.py
@@ -1,5 +1,4 @@
-import nose
-import dpath.util
+import mkpy.dpath as dpath
 
 
 def test_set_existing_separator():

--- a/mkpy/dpath/path.py
+++ b/mkpy/dpath/path.py
@@ -2,9 +2,8 @@
 # import dpath.exceptions
 # import dpath.options
 
-from . import PY3
-from . import exceptions as dpath_exceptions
-from . import options as dpath_options
+from mkpy.dpath import PY3
+import mkpy.dpath as dpath
 
 import re
 import fnmatch
@@ -70,7 +69,7 @@ def validate(path, regex=None):
         key = elem[0]
         strkey = str(key)
         if regex and (not regex.findall(strkey)):
-            raise dpath_exceptions.InvalidKeyName(
+            raise dpath.exceptions.InvalidKeyName(
                 "{} at {} does not match the expression {}"
                 "".format(strkey, validated, regex.pattern)
             )
@@ -103,10 +102,10 @@ def paths(obj, dirs=True, leaves=True, path=[], skip=False):
 
         for (k, v) in iteritems:
             if issubclass(k.__class__, (string_class)):
-                if (not k) and (not dpath_options.ALLOW_EMPTY_STRING_KEYS):
-                    raise dpath_exceptions.InvalidKeyName(
+                if (not k) and (not dpath.options.ALLOW_EMPTY_STRING_KEYS):
+                    raise dpath.exceptions.InvalidKeyName(
                         "Empty string keys not allowed without "
-                        "dpath_options.ALLOW_EMPTY_STRING_KEYS=True"
+                        "dpath.options.ALLOW_EMPTY_STRING_KEYS=True"
                     )
                 elif skip and k[0] == "+":
                     continue
@@ -146,7 +145,7 @@ def match(path, glob):
     if "**" in glob:
         ss = glob.index("**")
         if "**" in glob[ss + 1 :]:
-            raise dpath_exceptions.InvalidGlob(
+            raise dpath.exceptions.InvalidGlob(
                 "Invalid glob. Only one '**' is permitted per glob."
             )
 
@@ -257,7 +256,7 @@ def set(obj, path, value, create_missing=True, afilter=None):
         if (not tester(obj, elem)) and (create_missing):
             creator(obj, elem)
         elif not tester(obj, elem):
-            raise dpath_exceptions.PathNotFound(
+            raise dpath.exceptions.PathNotFound(
                 "{} does not exist in {}".format(elem, traversed)
             )
         traversed.append(elem_value)
@@ -317,7 +316,7 @@ def get(obj, path, view=False, afilter=None):
 
         if not issubclass(target.__class__, (MutableSequence, MutableMapping)):
             if afilter and (not afilter(target)):
-                raise dpath_exceptions.FilteredValue
+                raise dpath.exceptions.FilteredValue
 
         index += 1
 

--- a/mkpy/dpath/util.py
+++ b/mkpy/dpath/util.py
@@ -1,8 +1,8 @@
 # import dpath.path
 # import dpath.exceptions
 
-from . import path as dpath_path
-from . import exceptions as dpath_exception
+import mkpy.dpath.path
+import mkpy.dpath.exceptions
 
 import traceback
 
@@ -38,7 +38,7 @@ def __safe_path__(path, separator):
         key = elem[0]
         strkey = str(key)
         if separator and (separator in strkey):
-            raise dpath_exceptions.InvalidKeyName(
+            raise mkpy.dpath.exceptions.InvalidKeyName(
                 "{0} at {1} contains the separator {2}"
                 "".format(strkey, separator.join(validated), separator)
             )
@@ -57,8 +57,8 @@ def new(obj, path, value, separator="/"):
     keys
     """
     pathlist = __safe_path__(path, separator)
-    pathobj = dpath_path.path_types(obj, pathlist)
-    return dpath_path.set(obj, pathobj, value, create_missing=True)
+    pathobj = mkpy.dpath.path.path_types(obj, pathlist)
+    return mkpy.dpath.path.set(obj, pathobj, value, create_missing=True)
 
 
 def delete(obj, glob, separator="/", afilter=None):
@@ -90,7 +90,7 @@ def delete(obj, glob, separator="/", afilter=None):
             prev.pop(item[0])
         deleted += 1
     if not deleted:
-        raise dpath_exceptions.PathNotFound(
+        raise mkpy.dpath.exceptions.PathNotFound(
             "Could not find {0} to delete it".format(glob)
         )
     return deleted
@@ -105,7 +105,7 @@ def set(obj, glob, value, separator="/", afilter=None):
     globlist = __safe_path__(glob, separator)
     for path in _inner_search(obj, globlist, separator):
         changed += 1
-        dpath_path.set(obj, path, value, create_missing=False, afilter=afilter)
+        mkpy.dpath.path.set(obj, path, value, create_missing=False, afilter=afilter)
     return changed
 
 
@@ -122,7 +122,7 @@ def get(obj, glob, separator="/"):
     for item in search(obj, glob, yielded=True, separator=separator):
         if ret is not None:
             raise ValueError(
-                "dpath.util.get() globs must match only one leaf : %s" % glob
+                "mkpy.dpath.util.get() globs must match only one leaf : %s" % glob
             )
         ret = item[1]
         found = True
@@ -140,7 +140,7 @@ def values(obj, glob, separator="/", afilter=None, dirs=True):
     """
     return [
         x[1]
-        for x in dpath.util.search(
+        for x in mkpy.dpath.util.search(
             obj,
             glob,
             yielded=True,
@@ -166,9 +166,9 @@ def search(obj, glob, yielded=False, separator="/", afilter=None, dirs=True):
         globlist = __safe_path__(glob, separator)
         for path in _inner_search(obj, globlist, separator, dirs=dirs):
             try:
-                val = dpath_path.get(obj, path, afilter=afilter, view=True)
+                val = mkpy.dpath.path.get(obj, path, afilter=afilter, view=True)
                 merge(view, val)
-            except dpath_exceptions.FilteredValue:
+            except mkpy.dpath.exceptions.FilteredValue:
                 pass
         return view
 
@@ -176,12 +176,12 @@ def search(obj, glob, yielded=False, separator="/", afilter=None, dirs=True):
         globlist = __safe_path__(glob, separator)
         for path in _inner_search(obj, globlist, separator, dirs=dirs):
             try:
-                val = dpath_path.get(obj, path, view=False, afilter=afilter)
+                val = mkpy.dpath.path.get(obj, path, view=False, afilter=afilter)
                 yield (
-                    separator.join(map(str, dpath_path.paths_only(path))),
+                    separator.join(map(str, mkpy.dpath.path.paths_only(path))),
                     val,
                 )
-            except dpath_exceptions.FilteredValue:
+            except mkpy.dpath.exceptions.FilteredValue:
                 pass
 
     if afilter is not None:
@@ -193,8 +193,8 @@ def search(obj, glob, yielded=False, separator="/", afilter=None, dirs=True):
 
 def _inner_search(obj, glob, separator, dirs=True, leaves=False):
     """Search the object paths that match the glob."""
-    for path in dpath_path.paths(obj, dirs, leaves, skip=True):
-        if dpath_path.match(path, glob):
+    for path in mkpy.dpath.path.paths(obj, dirs, leaves, skip=True):
+        if mkpy.dpath.path.match(path, glob):
             yield path
 
 

--- a/mkpy/dpath/util.py
+++ b/mkpy/dpath/util.py
@@ -105,7 +105,9 @@ def set(obj, glob, value, separator="/", afilter=None):
     globlist = __safe_path__(glob, separator)
     for path in _inner_search(obj, globlist, separator):
         changed += 1
-        mkpy.dpath.path.set(obj, path, value, create_missing=False, afilter=afilter)
+        mkpy.dpath.path.set(
+            obj, path, value, create_missing=False, afilter=afilter
+        )
     return changed
 
 
@@ -122,7 +124,8 @@ def get(obj, glob, separator="/"):
     for item in search(obj, glob, yielded=True, separator=separator):
         if ret is not None:
             raise ValueError(
-                "mkpy.dpath.util.get() globs must match only one leaf : %s" % glob
+                "mkpy.dpath.util.get() globs must match only one leaf : %s"
+                % glob
             )
         ret = item[1]
         found = True
@@ -166,7 +169,9 @@ def search(obj, glob, yielded=False, separator="/", afilter=None, dirs=True):
         globlist = __safe_path__(glob, separator)
         for path in _inner_search(obj, globlist, separator, dirs=dirs):
             try:
-                val = mkpy.dpath.path.get(obj, path, afilter=afilter, view=True)
+                val = mkpy.dpath.path.get(
+                    obj, path, afilter=afilter, view=True
+                )
                 merge(view, val)
             except mkpy.dpath.exceptions.FilteredValue:
                 pass
@@ -176,7 +181,9 @@ def search(obj, glob, yielded=False, separator="/", afilter=None, dirs=True):
         globlist = __safe_path__(glob, separator)
         for path in _inner_search(obj, globlist, separator, dirs=dirs):
             try:
-                val = mkpy.dpath.path.get(obj, path, view=False, afilter=afilter)
+                val = mkpy.dpath.path.get(
+                    obj, path, view=False, afilter=afilter
+                )
                 yield (
                     separator.join(map(str, mkpy.dpath.path.paths_only(path))),
                     val,


### PR DESCRIPTION
Juggled mkpy/dpath module imports for mkpy.dpath so pytest passes

`.travis.yml` still needs to install `nose` to run the dpath tests
