### PR TITLE
release 0.1.6 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
     - conda build conda -c defaults -c conda-forge
     - conda create --name mkpy_env mkpy -c local -c defaults -c conda-forge
     - conda activate mkpy_env  # so tests run in env as installed by conda
-    - conda install black pytest-cov nose
+    - conda install black pytest-cov
     - conda list
     - lscpu
     - python -c 'import numpy; numpy.show_config()'

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.5" %}
+{% set version = "0.1.6" %}
 {% set np_pin = "1.16.4" %}
 {% set py_pin = "3.6" %}
 
@@ -24,7 +24,6 @@ requirements:
   run:
     - python ={{ py_pin }}  # cythonize with 3.6
     - numpy =={{ np_pin }}  # { pin_compatible('numpy') }}
-    - pytest  # include so users can run tests of installation
     - h5py
     - matplotlib
     - pandas
@@ -32,6 +31,8 @@ requirements:
     - PyYAML
     - xlrd
     - yamllint
+    - pytest  # include so users can run tests
+    - nose  # for legacy dpath tests
 
 test:
   imports:

--- a/mkpy/__init__.py
+++ b/mkpy/__init__.py
@@ -14,7 +14,7 @@ from pprint import pformat
 import re
 from . import dpath
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 
 def get_ver():

--- a/tests/test_mkpy.py
+++ b/tests/test_mkpy.py
@@ -1,7 +1,11 @@
-import re
 from pathlib import Path
 import mkpy
 from mkpy import get_ver
+
+
+def test_mkpy__init__version():
+    # screen version for updates
+    assert mkpy.__version__ == "0.1.6"
 
 
 def test_mkpy__init__getver():


### PR DESCRIPTION
moved nose into conda requirements so users can run full test of local conda installation