### PR TITLE
add mne convenience functions to mkpy.io.mkh5mne

### DIFF
--- a/mkpy/__init__.py
+++ b/mkpy/__init__.py
@@ -12,9 +12,10 @@ import sys
 import traceback
 from pprint import pformat
 import re
-from . import dpath
 
-__version__ = "0.2.5.dev2"
+# from . import dpath
+
+__version__ = "0.2.5.dev3"
 
 
 def get_ver():

--- a/tests/test_io_mkh5mne.py
+++ b/tests/test_io_mkh5mne.py
@@ -319,7 +319,7 @@ def test_read_raw_mkh5_apparatus_yaml():
     mkh5mne.read_raw_mkh5(TEST_RAW_MKH5_FILE, apparatus_yaml=TEST_APPARATUS_YAML)
 
 
-@pytest.mark.parametrize("garv_interval", [None, [-500, 1500, "ms"]])
+@pytest.mark.parametrize("garv_interval", [[-500, 1500, "ms"], None])
 def test_read_write_raw(garv_interval):
 
     infix = "_".join([str(p) for p in garv_interval]) if garv_interval else "_None"
@@ -345,11 +345,65 @@ def test_read_write_raw(garv_interval):
         )
 
 
-@pytest.mark.skip(reson="file too large for travis")
-def test_large_read_raw():
-    LARGE_FILE = (
-        "/home/projects/logmets/private/data/eeg/lm_eeg_1_mkpy/test_lm_eeg_1.h5"
+def test_get_garv_bads():
+
+    onsets = [44.048, 45.176, 54.112, 63.556, 96.576, 103.392, 118.416]
+    durations = [0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 0.024]
+    descriptions = ["BAD_garv_48"] * 3 + ["BAD_garv_32"] + ["BAD_garv_48"] * 3
+    dbps = mkh5.mkh5(TEST_EPOCHS_MKH5_FILE).dblock_paths
+    raw_mkh5 = mkh5mne.read_raw_mkh5(
+        TEST_EPOCHS_MKH5_FILE, dblock_paths=dbps[0:1],  # one block to shorten test time
     )
-    mne_raw = mkh5mne.read_raw_mkh5(
-        LARGE_FILE, apparatus_yaml=TEST_APPARATUS_YAML, skip_checks=True
+    bad_garvs = mkh5mne.get_garv_bads(raw_mkh5, "ms100", garv_interval=[-12, 12, "ms"])
+    assert all(bad_garvs.onset == onsets)
+    assert all(bad_garvs.duration == durations)
+    assert all(bad_garvs.description == descriptions)
+
+
+def test_get_epochs():
+    """smoke test get_mkh5_epochs which also traverses get_epochs_metadata"""
+
+    dbps = mkh5.mkh5(TEST_EPOCHS_MKH5_FILE).dblock_paths
+    raw_mkh5 = mkh5mne.read_raw_mkh5(
+        TEST_EPOCHS_MKH5_FILE, dblock_paths=dbps[0:1],  # one block to shorten test time
     )
+
+    metadata = mkh5mne.get_epochs_metadata(raw_mkh5, epochs_name="ms100")
+    epochs = mkh5mne.get_epochs(
+        raw_mkh5,
+        epochs_name="ms100",
+        baseline=(None, 0),  # mne syntax for prestim baseline
+        preload=True,
+    )
+    assert all(epochs.metadata.columns == metadata.columns)
+
+    coi = [
+        "epoch_id",
+        "data_group",
+        "dblock_path",
+        "dblock_ticks",
+        "mne_dblock_path_idx",
+        "mne_raw_ticks",
+        "match_tick",
+        "anchor_tick",
+        "diti_t_0",
+        "diti_hop",
+        "diti_len",
+        "instrument",
+        "bin",
+        "tone",
+        "stim",
+        "log_evcodes",
+        "log_flags",
+        "log_ccodes",
+        "regexp",
+        "match_time",
+        "match_code",
+        "anchor_code",
+        "accuracy",
+        "acc_type",
+    ]
+    epochs_coi = mkh5mne.get_epochs(
+        raw_mkh5, epochs_name="ms100", metadata_columns=coi
+    )
+    assert all(epochs_coi.metadata.columns == coi)

--- a/tests/test_io_mkh5mne.py
+++ b/tests/test_io_mkh5mne.py
@@ -403,7 +403,5 @@ def test_get_epochs():
         "accuracy",
         "acc_type",
     ]
-    epochs_coi = mkh5mne.get_epochs(
-        raw_mkh5, epochs_name="ms100", metadata_columns=coi
-    )
+    epochs_coi = mkh5mne.get_epochs(raw_mkh5, epochs_name="ms100", metadata_columns=coi)
     assert all(epochs_coi.metadata.columns == coi)


### PR DESCRIPTION
* `read_raw_mkh5()` user API unchanged, revised annotation construction under the hood
* `get_garv_bads()` convert event-based garv log_flags to mne annotation intervals with `BAD_garv_N` string descriptions
* `get_epochs()`  fetch mne.Epoch instance with mkh5 epochs table metadata from an mkh5raw format mne.Raw instance
* `get_epochs_metadata()` fetch mkh5 epochs table metadata from an mkh5 raw format mne.Raw instance.
