### PR TITLE
Minor patches for recent MNE and pandas

### DIFF
--- a/.github/workflows/mkpy_cid.yml
+++ b/.github/workflows/mkpy_cid.yml
@@ -5,15 +5,15 @@
 # Based on spudtr/.github/workflows/spudtr_cid.yml
 # 
 # - canonical package semantic version strings are M.N.P and M.N.P.devX
-# - job matrix runs on linux-64 for Python 3.6, 3.7, 3.8
+# - job matrix runs on linux-64 for Python 3.7, 3.8, 3.9
 # - each py3X job builds, installs, pytests, and deploys its own conda py3X packages
 # - one py3X job deploys codecov, python package sdist, and docs
 # - cron runs daily to conda build, install, pytest the latest commit on default branch
 #
 # CI:
 #
-#   - conda build, install, and pytest the conda packages linux-64 py3[678]
-#   - conda convert py3[678] x [osx-64, win-64] (untested)
+#   - conda build, install, and pytest the conda packages linux-64 py3[789]
+#   - conda convert py3[789] x [osx-64, win-64] (untested)
 #   - build sphinx docs
 #   # NA - build python package sdist
 #
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        py_ver: [3.6, 3.7, 3.8]
+        py_ver: [3.7, 3.8, 3.9]
 
     env:
       PY_VER: ${{ matrix.py_ver }}
@@ -104,19 +104,29 @@ jobs:
           hash -r
           conda config --set always_yes yes --set changeps1 no
           conda config --set bld_path $CONDA_BLD_PATH
-          conda install -q conda-build conda-verify anaconda twine
+
+          # switch to mamba/boa and conda-forge
+          conda config --add channels conda-forge
+
+          # revised mamba channel priority semantics, strict in 0.14 is flexible in 0.15
+          conda config --set channel_priority flexible  # should be default but enforce
+          conda install -n base -q conda-build conda-verify anaconda-client twine mamba boa
+          echo "# ------------------------------------------------------------"
           conda info -a
+          echo "# ------------------------------------------------------------"
+          mamba info -a
+
 
       # ------------------------------------------------------------
       # 2. CI
-      - name: conda build --python=${{ env.PY_VER }} conda
+      - name: conda mambabuild --python=${{ env.PY_VER }} conda
         id: conda-bld
         run: |
-          conda build --python=$PY_VER -c defaults -c conda-forge conda
+          conda mambabuild --python=$PY_VER conda
           tarball=$(conda build --python=$PY_VER conda --output | tail -1)
           # not converting b.c. of Cythonization
           # conda convert -p osx-64 -p win-64 -o $CONDA_BLD_PATH $tarball
-          # not converting other platforms b.c. of Cythonization
+          # not converting other platforms b.c. of Cythnization
           # conda convert -p osx-64 -p win-64 -o $CONDA_BLD_PATH $tarball
           echo "conda build tarball: " $tarball
           echo "::set-output name=conda-tarball::$tarball"
@@ -128,10 +138,9 @@ jobs:
           env_${{ env.PY_VER }}
           python=${{ env.PY_VER }}
           ${{ env.PACKAGE_NAME}}
-          -c local -c defaults -c conda-forge
 
         run: |
-          conda create -n env_$PY_VER python=$PY_VER $PACKAGE_NAME -c local -c defaults -c conda-forge
+          conda create -n env_$PY_VER python=$PY_VER $PACKAGE_NAME -c $CONDA_BLD_PATH
           conda activate env_$PY_VER
           conda install -q black pytest pytest-cov
           conda list
@@ -140,14 +149,15 @@ jobs:
           black --check --verbose .
           pytest --cov=$PACKAGE_NAME # test as installed by conda
 
+
       - name: build sphinx docs
         if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}
         run: |
           conda activate env_$PY_VER  # required to run doc demos
           # conda install -q sphinx sphinx_rtd_theme jupyter nbsphinx "nbconvert!=5.4" -c defaults -c conda-forge
-          conda install -q sphinx sphinx_rtd_theme jupyter sphinx-gallery -c defaults -c conda-forge
+          conda install -q sphinx sphinx_rtd_theme jupyter sphinx-gallery
           # python setup.py build_ext  # so sphinx-gallery has mkpy/_mkh5 in the source dir
-          conda install -q pandoc -c conda-forge
+          conda install -q pandoc
           make -C mkpy/docs html
           touch $GITHUB_WORKSPACE/mkpy/docs/_build/html/.nojekyll
           ls -l $GITHUB_WORKSPACE/mkpy/docs/_build/html

--- a/.github/workflows/mkpy_cid.yml
+++ b/.github/workflows/mkpy_cid.yml
@@ -110,7 +110,7 @@ jobs:
 
           # revised mamba channel priority semantics, strict in 0.14 is flexible in 0.15
           conda config --set channel_priority flexible  # should be default but enforce
-          conda install -n base -q conda-build conda-verify anaconda-client twine mamba boa
+          conda install -n base -q conda-build cython conda-verify anaconda-client twine mamba boa
           echo "# ------------------------------------------------------------"
           conda info -a
           echo "# ------------------------------------------------------------"

--- a/.github/workflows/mkpy_cid.yml
+++ b/.github/workflows/mkpy_cid.yml
@@ -110,7 +110,7 @@ jobs:
 
           # revised mamba channel priority semantics, strict in 0.14 is flexible in 0.15
           conda config --set channel_priority flexible  # should be default but enforce
-          conda install -n base -q conda-build cython conda-verify anaconda-client twine mamba boa
+          conda install -n base -q numpy cython conda-build conda-verify anaconda-client twine mamba boa
           echo "# ------------------------------------------------------------"
           conda info -a
           echo "# ------------------------------------------------------------"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-#  host:
+  host:
     - python {{ python }}
     - setuptools
     - cython

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-  host:
+#  host:
     - python {{ python }}
     - setuptools
     - cython
@@ -40,7 +40,8 @@ requirements:
     - pytest  !=5.3.4 # so users can run tests, bad release fights with nose
     - nose  # for legacy dpath tests
     - requests  # TravisCI pytests download test data files too large for github
-    - mne >=0.20.0=py3*  # mne noarch is a brutally slow dependency solve
+    # - mne >=0.20.0=py3*  # mne noarch is a brutally slow dependency solve
+    - mne >=0.20  # allow noarch builds w/ conda-forge priority
 
 test:
   imports:

--- a/mkpy/__init__.py
+++ b/mkpy/__init__.py
@@ -15,7 +15,7 @@ import re
 
 # from . import dpath
 
-__version__ = "0.2.5.dev7"
+__version__ = "0.2.5.dev8"
 
 
 def get_ver():

--- a/tests/test_event_tables.py
+++ b/tests/test_event_tables.py
@@ -254,11 +254,11 @@ def test_non_unique_event_table_index(sheet):
 
         # spot check the word_lag rows
         if len(row_slice) == 1:
-            assert row_slice["word_lag"].all() in events[sheet]["word_lags_1"]
+            assert row_slice["word_lag"].unique() in events[sheet]["word_lags_1"]
         elif len(row_slice) in [2, 3]:
             # duplicate indices, multiple rows match, make sure the
-            # the right number comes back
-            assert row_slice["word_lag"].all() in events[sheet]["word_lags_2_3"]
+            # the right values come back
+            assert row_slice["word_lag"].unique() in events[sheet]["word_lags_2_3"]
         elif len(row_slice) == 209:
             assert row_slice["word_lag"].unique()[0] == "cal"
         else:


### PR DESCRIPTION
* update mkh5mne mne.Info comparisons for MNE 0.23. In 0.23 the `custom_ref_applied` flag is an MNE named integer type when a custom  ref is applied to mne.Raw.info but the raw write, raw read round trip converts it to an int so the `object_hash` comparison fails but `==` succeeds.

* Patch test_event_tables.py for some change in pandas row slice behavior.
